### PR TITLE
Compatibility templating change for Symfony 4, 5

### DIFF
--- a/DependencyInjection/Compiler/FormPass.php
+++ b/DependencyInjection/Compiler/FormPass.php
@@ -29,7 +29,7 @@ class FormPass implements CompilerPassInterface
         $resources = $container->getParameter('twig.form.resources');
 
         foreach (array('div', 'jquery', 'stylesheet') as $template) {
-            $resources[] = 'SCDatetimepickerBundle:Form:' . $template . '_layout.html.twig';
+            $resources[] = '@SCDatetimepicker/Form/' . $template . '_layout.html.twig';
         }
 
         $container->setParameter('twig.form.resources', $resources);


### PR DESCRIPTION
Fix deprecate the integration of the Templating component https://symfony.com/blog/new-in-symfony-4-3-deprecated-the-templating-component-integration

Removing from config.yml framework.templating.engines create error

`Template reference "SCDatetimepickerBundle:Form:X_layout.html.twig" not found, did you mean "@SCDatetimepicker/Form/X_layout.html.twig"?`

Tested on my Symfony 3.4 and 4.4 app - works fine. Thank you.